### PR TITLE
Use relative library build path

### DIFF
--- a/RTEditor-Demo/build.gradle
+++ b/RTEditor-Demo/build.gradle
@@ -76,5 +76,6 @@ android {
 }
 
 dependencies {
-    compile 'com.1gravity:android-rteditor:1.2.1'
+    compile project(':RTEditor')
+    compile project(':RTEditor-Toolbar')
 }

--- a/RTEditor-Toolbar/build.gradle
+++ b/RTEditor-Toolbar/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    compile 'com.1gravity:android-rteditor-core:1.2.1'
+    compile project(':RTEditor');
 }
 
 apply from: '../android-artifacts.gradle'

--- a/RTEditor/build.gradle
+++ b/RTEditor/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    compile 'com.1gravity:android-rteditor-colorpicker:1.2.1'
+    compile project(':ColorPicker');
 }
 
 apply from: '../android-artifacts.gradle'


### PR DESCRIPTION
Hi,

I would like to make some changes to see if it your RTE can fit to my requirements. 
I think it would be much better if you are using the local path for libraries to build the project.
Then it's easier to clone the project and make few changes.