### PR TITLE
Calculate list item indicator (bullet, number) size based on the text size

### DIFF
--- a/RTEditor/src/main/java/com/onegravity/rteditor/spans/BaseListItemSpan.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/spans/BaseListItemSpan.java
@@ -1,0 +1,43 @@
+package com.onegravity.rteditor.spans;
+
+import android.text.Spanned;
+
+abstract class BaseListItemSpan {
+    float determineTextSize(Spanned spanned, int start, int end, float defaultTextSize) {
+        // If the text size is different from default use that to determine the indicator size
+        // That is determined by finding the first visible character within the list item span
+        // and checking its size
+        int position = firstVisibleCharIndex(spanned, start, end);
+        if (position >= 0) {
+            AbsoluteSizeSpan[] absoluteSizeSpans = spanned.getSpans(position, position, AbsoluteSizeSpan.class);
+            if (absoluteSizeSpans.length > 0) {
+                AbsoluteSizeSpan absoluteSizeSpan = absoluteSizeSpans[absoluteSizeSpans.length - 1];
+                return absoluteSizeSpan.getValue();
+            }
+        }
+
+        // If there are no spans or no visible characters yet use the default calculation
+        return defaultTextSize;
+    }
+
+    private int firstVisibleCharIndex(Spanned spanned, int start, int end) {
+        while (start < end) {
+            if (isVisibleChar(spanned.charAt(start))) {
+                return start;
+            }
+            start++;
+        }
+
+        return -1;
+    }
+
+    private boolean isVisibleChar(char c) {
+        switch (c) {
+            case '\u200B':
+            case '\uFFEF':
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/RTEditor/src/main/java/com/onegravity/rteditor/spans/BulletSpan.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/spans/BulletSpan.java
@@ -33,7 +33,7 @@ import android.text.style.LeadingMarginSpan;
  * we ignore the leading margin for the last, empty paragraph unless it's the
  * only one
  */
-public class BulletSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagraphSpan<Boolean> {
+public class BulletSpan extends BaseListItemSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagraphSpan<Boolean> {
 
     private static Path sBulletPath = null;
 
@@ -68,7 +68,7 @@ public class BulletSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagra
             p.setStyle(Paint.Style.FILL);
 
             // draw the bullet point
-            int size = Math.max(Math.round((baseline - top) / 9f), 4);
+            int size = Math.max(Math.round(determineTextSize(spanned, start, end, p.getTextSize()) / 9f), 4);
             draw(c, p, x, dir, top, bottom, size);
 
             // restore paint

--- a/RTEditor/src/main/java/com/onegravity/rteditor/spans/NumberSpan.java
+++ b/RTEditor/src/main/java/com/onegravity/rteditor/spans/NumberSpan.java
@@ -29,13 +29,12 @@ import android.text.style.LeadingMarginSpan;
  * (]0, 4][4, 4] --> the leading margin of the second span is added to the ]0, 4] paragraph regardless of the Spanned.flags)
  * --> therefore we ignore the leading margin for the last, empty paragraph unless it's the only one
  */
-public class NumberSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagraphSpan<Boolean> {
+public class NumberSpan extends BaseListItemSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagraphSpan<Boolean> {
 
     private final int mNr;
     private final int mGapWidth;
     private final boolean mIgnoreSpan;
 
-    private float mTextSize = 10f;
     private float mWidth;
 
     public NumberSpan(int nr, int gapWidth, boolean isEmpty, boolean isFirst, boolean isLast) {
@@ -65,8 +64,8 @@ public class NumberSpan implements LeadingMarginSpan, RTSpan<Boolean>, RTParagra
             Paint.Style oldStyle = p.getStyle();
             float oldTextSize = p.getTextSize();
             p.setStyle(Paint.Style.FILL);
-            mTextSize = baseline - top;
-            p.setTextSize(mTextSize);
+            float textSize = determineTextSize(spanned, start, end, oldTextSize);
+            p.setTextSize(textSize);
             mWidth = p.measureText(mNr + ".");
 
             // draw the number


### PR DESCRIPTION
This is to address the issue raised in the https://github.com/1gravity/Android-RTEditor/pull/116 but also keeping the text size relevant. Personally I found it the most aesthetically pleasing for the bullet size to match the text size of the first character following the bullet (I believe this is the same approach Google Docs has taken). See the screenshots of before and after the patch that show that the bullets grow in size if the text size changes.

Before the patch
![no-patch-text-only](https://user-images.githubusercontent.com/1417338/32681639-52a93360-c625-11e7-85bb-07cced3979e6.png)
![no-patch-images](https://user-images.githubusercontent.com/1417338/32681637-527dd71a-c625-11e7-86d1-80edb5257223.png)
![no-patch-text-and-images](https://user-images.githubusercontent.com/1417338/32681638-529392e4-c625-11e7-8778-c21b9ce2f3ab.png)

After the patch, no text size picked
![patch-images-default-size](https://user-images.githubusercontent.com/1417338/32681640-52c06fd0-c625-11e7-8a2b-495ec2f411ef.png)
![patch-text-and-images-default-size](https://user-images.githubusercontent.com/1417338/32681642-52edc2f0-c625-11e7-9de2-29d72f9ff375.png)

After the patch, text size is set
![patch-text-only](https://user-images.githubusercontent.com/1417338/32681643-53050442-c625-11e7-900c-2f65d8a0221b.png)
![patch-images-explicit-size](https://user-images.githubusercontent.com/1417338/32681641-52d6cb22-c625-11e7-8ce5-fd36adffa71c.png)
![pathc-text-and-images-explicit-size](https://user-images.githubusercontent.com/1417338/32681644-531c9e0e-c625-11e7-9035-e5e87d9c0eac.png)
